### PR TITLE
fix: fixed popular categories query and template

### DIFF
--- a/services/category_service.py
+++ b/services/category_service.py
@@ -34,10 +34,9 @@ async def get_all_categories(session: AsyncSession) -> List[Category]:
 async def popular_categories(session: AsyncSession) -> List[Category]:
     query = await session.execute(select(
             Category, func.count(Ad.id))
-            .join(Category.subcategories)
-            .join(Subcategory.ads)
+            .join(Subcategory, Subcategory.id == Ad.subcategory_id)
+            .join(Category, Subcategory.id == Category.id)
             .group_by(Category.id)
-            .order_by(func.count(Ad.id).desc())
             .limit(10)
     )
     popular_categories = query.scalars().all()

--- a/templates/home/index.pt
+++ b/templates/home/index.pt
@@ -97,7 +97,8 @@
         <div
           class="category_wrapper d-flex flex-wrap justify-content-center pt-30"
         >
-          <div tal:repeat="category popular_categories" tal:omit-tag="True" class="category-column">
+        <__repeat tal:repeat="category popular_categories" tal:omit-tag="True">
+          <div class="category-column">
             <div class="single_category text-center mt-30">
               <div class="icon">
                 <i class="${category.category_icon}"></i>
@@ -108,6 +109,7 @@
               <a href="/products/product"></a>
             </div>
           </div>
+        </__repeat>
           <div class="category_btn">
             <a class="main-btn" href="/common/categories">Ver todas as categorias</a>
           </div>


### PR DESCRIPTION
Fixed the popular_categories def that was only getting 2 categories, now it returns 10 of them. Also ajusted the template because it wasn't displaying correctively.